### PR TITLE
Build with modern mingw64 properly, use new SystemAccess DLL name.

### DIFF
--- a/src/windows/hook.c
+++ b/src/windows/hook.c
@@ -37,7 +37,7 @@ return CallNextHookEx(hook, code, wp, lp);
 export BOOL installKeyboardHook (void) {
 if (hook) uninstallKeyboardHook();
 if (hook) return TRUE;
-hook = SetWindowsHookEx( WH_KEYBOARD_LL, kbHook, GetModuleHandle(NULL), NULL);
+hook = SetWindowsHookEx( WH_KEYBOARD_LL, kbHook, GetModuleHandle(NULL), 0);
 return !!hook;
 }
 

--- a/src/windows/nvda.c
+++ b/src/windows/nvda.c
@@ -32,7 +32,7 @@ nvdaUnload();
 nvda = LoadLibraryW(composePath(L"nvdaControllerClient.dll"));
 if (!nvda) nvda = LoadLibraryW(composePath(L"nvdaControllerClient32.dll"));
 if (!nvda) return FALSE;
-#define LOAD(f) { f=GetProcAddress(nvda,#f); if (!f) { nvdaUnload(); return FALSE; }}
+#define LOAD(f) { *(void**)(&f) = (void*)GetProcAddress(nvda, #f); if (!f) { nvdaUnload(); return FALSE; }}
 LOAD(nvdaController_testIfRunning) LOAD(nvdaController_speakText)
 LOAD(nvdaController_cancelSpeech) LOAD(nvdaController_brailleMessage)
 #undef LOAD

--- a/src/windows/processlist.c
+++ b/src/windows/processlist.c
@@ -53,7 +53,7 @@ BOOL result = FALSE;
 if (LPQueryFullProcessImageNameA) result =  LPQueryFullProcessImageNameA(h, 0, name, &namelen);
 else result = GetProcessImageFileName(h,name,512);
 if (!result) continue;
-if(stristr(name, needle)) {
+if(strstr(name, needle)) {
 if (pfn&&pfnsz>0) {
 if (LPQueryFullProcessImageNameA) snprintf(pfn, pfnsz, "%s", name);
 else DriverPathToNormalPath(name, pfn, pfnsz);

--- a/src/windows/systemaccess.c
+++ b/src/windows/systemaccess.c
@@ -34,7 +34,7 @@ systemaccess = NULL;
 
 export BOOL saLoad (void) {
 saUnload();
-systemaccess = LoadLibraryW(composePath(L"SAAPI32.DLL"));
+systemaccess = LoadLibraryW(composePath(L"sa_api.DLL"));
 if (!systemaccess) return FALSE;
 #define LOAD(f) { f = GetProcAddress(systemaccess,#f); if (!f) { saUnload(); return FALSE; }}
 LOAD(SA_IsRunning) LOAD(SA_StopAudio)

--- a/src/windows/zdsr.c
+++ b/src/windows/zdsr.c
@@ -29,7 +29,7 @@ export BOOL zdsrLoad (void) {
 zdsrUnload();
 zdsr = LoadLibraryW(composePath(L"zdsrapi.dll"));
 if (!zdsr) return FALSE;
-#define LOAD(f) { f=GetProcAddress(zdsr,#f); if (!f) { zdsrUnload(); return FALSE; }}
+#define LOAD(f) { *(void**)(&f) = (void*)GetProcAddress(zdsr, #f); if (!f) { zdsrUnload(); return FALSE; }}
 LOAD(InitTTS) LOAD(GetSpeakState)
 LOAD(Speak) LOAD(StopSpeak)
 #undef LOAD

--- a/src/windows/zoomtext-guid.c
+++ b/src/windows/zoomtext-guid.c
@@ -65,7 +65,7 @@ typedef IID CLSID;
 #define MIDL_DEFINE_GUID(type,name,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8) \
         const type name = {l,w1,w2,{b1,b2,b3,b4,b5,b6,b7,b8}}
 
-#endif !_MIDL_USE_GUIDDEF_
+#endif //!_MIDL_USE_GUIDDEF_
 
 MIDL_DEFINE_GUID(IID, LIBID_AiSquared,0x9FBBC98E,0xAE78,0x4A1C,0xB6,0x35,0x1E,0xCA,0x2F,0xBF,0xFB,0x40);
 


### PR DESCRIPTION
I updated the code to make it build with the latest Mingw/Gcc, the latest winlibs to be more exact. I also updated the system access loader to use the new sa_api.dll DLL name universally.